### PR TITLE
model-saver : emit kda_gate_lower_bound for Kimi K3

### DIFF
--- a/src/llama-model-saver.cpp
+++ b/src/llama-model-saver.cpp
@@ -319,6 +319,7 @@ void llama_model_saver::add_kv_from_model() {
     add_kv(LLM_KV_SSM_DT_B_C_RMS,                    hparams.ssm_dt_b_c_rms);
 
     add_kv(LLM_KV_KDA_HEAD_DIM,                      hparams.n_embd_head_kda);
+    add_kv(LLM_KV_KDA_GATE_LOWER_BOUND,              hparams.kda_gate_lower_bound);
 
     add_kv(LLM_KV_WKV_HEAD_SIZE,                     hparams.wkv_head_size);
 

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -248,6 +248,7 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
     ms.add_kv(LLM_KV_ATTN_RES_BLOCK_SIZE,       uint32_t(12));
     ms.add_kv(LLM_KV_ACTIVATION_SITU_BETA,      4.0f);
     ms.add_kv(LLM_KV_ACTIVATION_SITU_LINEAR_BETA, 25.0f);
+    ms.add_kv(LLM_KV_KDA_GATE_LOWER_BOUND,      -5.0f);
 
     for (uint32_t il = 0; il < n_layer; il++) {
         ggml_tensor t;


### PR DESCRIPTION
This is a simple follow-up to the Kimi K3 arch-test work (now merged into kimi-k3-text).

While the saver roundtrips the other K3 hyperparameters, it never emitted
kda_gate_lower_bound. The K3 loader reads that key and gates a graph branch on it. So in this way it scales the KDA gate when the bound is above -INFINITY (kimi-k3.cpp).
The saver dropped the key, thus a save->load roundtrip silently reset it to
the -INFINITY default and changed the model's output. The real K3 config sets
gate_lower_bound = -5.0.

Changes includes:
- llama-model-saver.cpp: emit LLM_KV_KDA_GATE_LOWER_BOUND from the model.
- test-llama-archs.cpp: set it to -5.0 in the K3 case so the roundtrip check
  actually exercises the key.

Verified with the test value in place, the save->load roundtrip FAILS without
the saver line and PASSES with it. The full test-llama-archs sweep shows no
regressions on the other arches.
