### PR TITLE
vulkan: allow proxy collectives without external semaphore FD functions

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17972,7 +17972,7 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     for (size_t i = 0; i < n_backends; i++) {
         comm->vkctx[i]  = (ggml_backend_vk_context *) backends[i]->context;
         comm->device[i] = comm->vkctx[i]->device;
-        ok = ok && comm->device[i]->external_memory_host && comm->device[i]->external_semaphore;
+        ok = ok && comm->device[i]->external_memory_host;
         comm->align = std::max(comm->align, (size_t) comm->device[i]->min_imported_host_pointer_alignment);
     }
     comm->fast = ok;
@@ -17994,7 +17994,8 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     if (comm->fast) {
         comm->pGetSemFd    = (PFN_vkGetSemaphoreFdKHR)    comm->device[0]->device.getProcAddr("vkGetSemaphoreFdKHR");
         comm->pImportSemFd = (PFN_vkImportSemaphoreFdKHR) comm->device[0]->device.getProcAddr("vkImportSemaphoreFdKHR");
-        comm->fast = comm->pGetSemFd && comm->pImportSemFd;
+        // Local timeline semaphores suffice for the portable proxy path.
+        comm->proxy = !comm->pGetSemFd || !comm->pImportSemFd;
     }
     if (comm->fast) {
         comm->prog.resize(n_backends);
@@ -18020,7 +18021,7 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         // signals/reads them locally, so it must not request exportable handles. Some devices (e.g. llvmpipe, or
         // RADV on older Mesa) cannot create exportable timeline semaphores at all, which would otherwise abort
         // init here instead of falling back to the proxy.
-        comm->proxy = getenv("GGML_VK_COMM_PROXY") != nullptr;
+        comm->proxy = comm->proxy || getenv("GGML_VK_COMM_PROXY") != nullptr;
         if (!comm->proxy && !ggml_vk_comm_opaque_fd_supported(comm)) {
             comm->proxy = true;
             GGML_LOG_INFO("ggml_vulkan: cross-device OPAQUE_FD timeline import unsupported; using portable CPU-proxy sync\n");


### PR DESCRIPTION
Would you be willing to merge this into your branch so if/when you pr makes it to llama repo it incudes these minor changes. As you can see below there was some significant gains from this minor change on my windows system. I am running dual rtx 9700's.

<html>
<body>
<!--StartFragment--><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Scope</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Allow the existing portable CPU-proxy collective path to initialize when Linux<br style="box-sizing: border-box;">external semaphore FD functions are unavailable. Host-importable memory remains<br style="box-sizing: border-box;">required. Missing FD functions select the proxy rather than disabling the fast<br style="box-sizing: border-box;">collective implementation; the explicit proxy option preserves that selection.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">One source file, four additions and three deletions. No harness changes, tuning<br style="box-sizing: border-box;">switches, diagnostic logging, or experimental Win32 import code are included.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Dependency and attribution</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This PR deliberately targets<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">review/pr25051-base</code>, not main, so it shows only<br style="box-sizing: border-box;">our incremental fix to the proposed allreduce implementation:</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;"><span class="reference" style="box-sizing: border-box; font-weight: 600; white-space: nowrap;"><svg data-component="Octicon" class="octicon octicon-git-pull-request-draft draft color-fg-muted mr-1" title="Draft" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 14a2.25 2.25 0 1 1 0-4.5 2.25 2.25 0 0 1 0 4.5ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM14 7.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0-4.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z"></path></svg><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4752038403" data-permission-text="Title is private" data-url="https://github.com/ggml-org/llama.cpp/issues/25051" data-hovercard-type="pull_request" data-hovercard-url="/ggml-org/llama.cpp/pull/25051/hovercard" href="https://github.com/ggml-org/llama.cpp/pull/25051" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; white-space: normal; text-underline-offset: 0.2rem;">vulkan: add allreduce function with cross-device CPU proxy and fix Tensor Parallel crash [EXPERIMENTAL]<span class="issue-shorthand" style="box-sizing: border-box; font-weight: 400; color: rgb(145, 152, 161);"> ggml-org/llama.cpp#25051</span></a></span><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px; padding: 0px; position: relative;"><li style="box-sizing: border-box; margin-left: 24px;">Base:<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">13ac9015672d4e934d97cd19dd46f3ede4536a41</code>.</li></ul></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Historical DFlash integration tests also used<br style="box-sizing: border-box;"><span class="reference" style="box-sizing: border-box; font-weight: 600; white-space: nowrap;"><svg data-component="Octicon" class="octicon octicon-git-pull-request-draft draft color-fg-muted mr-1" title="Draft" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 14a2.25 2.25 0 1 1 0-4.5 2.25 2.25 0 0 1 0 4.5ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM14 7.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0-4.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z"></path></svg><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="5275663770" data-permission-text="Title is private" data-url="https://github.com/ggml-org/llama.cpp/issues/27858" data-hovercard-type="pull_request" data-hovercard-url="/ggml-org/llama.cpp/pull/27858/hovercard" href="https://github.com/ggml-org/llama.cpp/pull/27858" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; white-space: normal; text-underline-offset: 0.2rem;">fix assertion DFlash2 with<span> </span><code style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--split-mode tensor</code><span> </span>on CUDA<span class="issue-shorthand" style="box-sizing: border-box; font-weight: 400; color: rgb(145, 152, 161);"> ggml-org/llama.cpp#27858</span></a></span><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px; padding: 0px; position: relative;"><li style="box-sizing: border-box; margin-left: 24px;">Revision:<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">3286b033c5dc8bcce9958f724d4e4a93ae589646</code>.</li></ul></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Related startup issue:<span> </span><span class="reference" style="box-sizing: border-box; font-weight: 600; white-space: nowrap;"><svg data-component="Octicon" class="octicon octicon-issue-opened open mr-1" title="Open" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path></svg><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="5272455702" data-permission-text="Title is private" data-url="https://github.com/ggml-org/llama.cpp/issues/27833" data-hovercard-type="issue" data-hovercard-url="/ggml-org/llama.cpp/issues/27833/hovercard" href="https://github.com/ggml-org/llama.cpp/issues/27833" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; white-space: normal; text-underline-offset: 0.2rem;">Eval bug: DFlash speculative decoding fails with --split-mode tensor (shared output.weight in Meta() buffer)<span class="issue-shorthand" style="box-sizing: border-box; font-weight: 400; color: rgb(145, 152, 161);"> ggml-org/llama.cpp#27833</span></a></span>.</li></ul><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The allreduce and DFlash implementations belong to their respective authors.<br style="box-sizing: border-box;">The tested combined tree also needed port adaptations; those are not part of<br style="box-sizing: border-box;">this small patch. Do not merge this base into main as if it were our own work.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Historical measurements and limits</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Two R9700s, Windows Vulkan, driver 32.0.23033.1002, Q4_K_S target and Q4 DFlash<br style="box-sizing: border-box;">drafter, Q8 K/V, flash attention, 32K context, one slot, concurrency one.<br style="box-sizing: border-box;">Short JSON/code/tool fixtures, same workload across comparisons:</p><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Combined integration | Passing requests | Aggregate output tokens/s
-- | -- | --
Before proxy initialization fix | 36/36 | 33.891
With proxy initialization fix | 36/36 | 38.797
Same-period single-card control | 12/12 | 55.703
Same-period dual-layer control | 12/12 | 44.395

</markdown-accessiblity-table><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">These are historical combined-build results, NOT a hardware benchmark of this<br style="box-sizing: border-box;">exact isolated patch on its PR25051-only base. Later post-reboot improvements<br style="box-sizing: border-box;">are not attributed to this fix. Tensor still did not beat single-card.<br style="box-sizing: border-box;">Short syntax/JSON/tool checks do not establish broad quality or correctness.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Direct TG16 diagnostic (one repetition, different settings from API tests):<br style="box-sizing: border-box;">17.235 before versus 19.540 tokens/s after; trace changed from fast=0 to<br style="box-sizing: border-box;">fast=1/proxy=1. No universal speedup is asserted.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(61, 68, 77, 0.7); padding-bottom: 0.3em; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Validation</h2><ul class="contains-task-list" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Patch applies to the exact pinned base.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Applied contents match expected extraction; reverse apply check passes.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Completed task" checked="" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">git diff --check</code><span> </span>passes.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Clean isolated patch build and matched hardware benchmark.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Regression test for capability/transport selection.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Backend-op correctness and perplexity validation.</li><li class="task-list-item enabled" style="box-sizing: border-box; list-style-type: none; margin-top: 0px; margin-left: -15px; border: 0px; margin-right: -15px; padding: 2px 15px 2px 42px; line-height: 1.5;"><span class="handle" style="box-sizing: border-box; display: block; float: left; opacity: 0; width: 20px; margin-left: -43px; padding: 2px 0px 0px 2px;"><svg class="drag-handle" aria-hidden="true" width="16" height="16"><path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path></svg></span><input type="checkbox" id="" class="task-list-item-checkbox" aria-label="Incomplete task" style="box-sizing: border-box; font: inherit; margin: 0px 0.2em 0.25em -1.4em; overflow: visible; padding: 0px; vertical-align: middle;"><span> </span>Linux native-FD regression and additional Windows workload coverage.</li></ul><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The fix is backend-level, not Python-harness-specific, but affects only<br style="box-sizing: border-box;">consumers using this proposed Vulkan meta-backend collective implementation.<br style="box-sizing: border-box;">Coordinate with the upstream PR author before any upstream submission.</p><!--EndFragment-->
</body>
</html>Scope
Allow the existing portable CPU-proxy collective path to initialize when Linux
external semaphore FD functions are unavailable. Host-importable memory remains
required. Missing FD functions select the proxy rather than disabling the fast
collective implementation; the explicit proxy option preserves that selection.

One source file, four additions and three deletions. No harness changes, tuning
switches, diagnostic logging, or experimental Win32 import code are included.

Dependency and attribution
This PR deliberately targets review/pr25051-base, not main, so it shows only
our incremental fix to the proposed allreduce implementation:

https://github.com/ggml-org/llama.cpp/pull/25051
Base: 13ac9015672d4e934d97cd19dd46f3ede4536a41.
Historical DFlash integration tests also used
https://github.com/ggml-org/llama.cpp/pull/27858
Revision: 3286b033c5dc8bcce9958f724d4e4a93ae589646.
Related startup issue: https://github.com/ggml-org/llama.cpp/issues/27833.
The allreduce and DFlash implementations belong to their respective authors.
The tested combined tree also needed port adaptations; those are not part of
this small patch. Do not merge this base into main as if it were our own work.

Historical measurements and limits
Two R9700s, Windows Vulkan, driver 32.0.23033.1002, Q4_K_S target and Q4 DFlash
drafter, Q8 K/V, flash attention, 32K context, one slot, concurrency one.
Short JSON/code/tool fixtures, same workload across comparisons:

Combined integration	Passing requests	Aggregate output tokens/s
Before proxy initialization fix	36/36	33.891
With proxy initialization fix	36/36	38.797
Same-period single-card control	12/12	55.703
Same-period dual-layer control	12/12	44.395
These are historical combined-build results, NOT a hardware benchmark of this
exact isolated patch on its PR25051-only base. Later post-reboot improvements
are not attributed to this fix. Tensor still did not beat single-card.
Short syntax/JSON/tool checks do not establish broad quality or correctness.

Direct TG16 diagnostic (one repetition, different settings from API tests):
17.235 before versus 19.540 tokens/s after; trace changed from fast=0 to
fast=1/proxy=1. No universal speedup is asserted.

Validation
 Patch applies to the exact pinned base.
 Applied contents match expected extraction; reverse apply check passes.
 git diff --check passes.
 Clean isolated patch build and matched hardware benchmark.
 Regression test for capability/transport selection.
 Backend-op correctness and perplexity validation.
 Linux native-FD regression and additional Windows workload coverage.
The fix is backend-level, not Python-harness-specific, but affects only
consumers using this proposed Vulkan meta-backend collective implementation.
Coordinate with the upstream PR author before any upstream submission.